### PR TITLE
Person $source is int

### DIFF
--- a/person.go
+++ b/person.go
@@ -47,7 +47,7 @@ type Person struct {
 	Organization string   `json:"$organization"`
 	PhoneNumber  string   `json:"$phone_number"`
 	Region       string   `json:"$region"`
-	Source       string   `json:"$source"`
+	Source       int      `json:"$source"`
 	Timezone     string   `json:"$timezone"`
 	Title        string   `json:"$title"`
 	Zip          string   `json:"$zip"`


### PR DESCRIPTION
$source as string returns with json unmarshal error. If there is a case that it can be both an int and a string, we need to allow for this in the future. 